### PR TITLE
Add custom keybindings for zsh-autosuggestions

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -33,6 +33,9 @@ source "${ZINIT_HOME}/zinit.zsh"
 zinit ice wait lucid
 zinit light zsh-users/zsh-syntax-highlighting
 
+# Keybindings - Must be loaded before plugins to override defaults
+[[ -f "${ZDOTDIR}/keybindings.zsh" ]] && source "${ZDOTDIR}/keybindings.zsh"
+
 # Auto-suggestions - Fish-like autosuggestions from history
 zinit ice wait lucid atload"_zsh_autosuggest_start"
 zinit light zsh-users/zsh-autosuggestions

--- a/keybindings.zsh
+++ b/keybindings.zsh
@@ -1,0 +1,68 @@
+# ============================================================================
+# keybindings.zsh - Custom Keybindings Configuration
+# ============================================================================
+# This file configures keybindings for zsh plugins and built-in features.
+# It must be sourced BEFORE plugins are loaded to override default settings.
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# zsh-autosuggestions Keybindings
+# ----------------------------------------------------------------------------
+# Customize behavior of autosuggestions from command history
+#
+# Desired behavior:
+#   When suggestion exists:
+#     - Right arrow (→):  Accept suggestion character by character
+#     - Ctrl+F:           Accept suggestion word by word
+#     - End key / Ctrl+E: Accept entire suggestion
+#   When no suggestion:
+#     - Right arrow (→):  Move forward one character
+#     - Ctrl+F:           Move forward one character
+#     - End key / Ctrl+E: Move to end of line
+#
+# Implementation:
+#   - Keep forward-char in PARTIAL_ACCEPT_WIDGETS (right arrow: char-by-char)
+#   - Add forward-word to PARTIAL_ACCEPT_WIDGETS (for word acceptance)
+#   - Create custom widget for Ctrl+F with conditional behavior
+
+# Widgets that accept the entire suggestion
+ZSH_AUTOSUGGEST_ACCEPT_WIDGETS=(
+  end-of-line
+  vi-end-of-line
+  vi-add-eol
+)
+
+# Widgets that accept suggestion word by word
+ZSH_AUTOSUGGEST_PARTIAL_ACCEPT_WIDGETS=(
+  forward-char
+  vi-forward-char
+  forward-word
+  emacs-forward-word
+  vi-forward-word
+  vi-forward-word-end
+  vi-forward-blank-word
+  vi-forward-blank-word-end
+  vi-find-next-char
+  vi-find-next-char-skip
+)
+
+# ----------------------------------------------------------------------------
+# Custom Key Bindings
+# ----------------------------------------------------------------------------
+# Custom widget for Ctrl+F: word-by-word acceptance when suggestion exists
+# AND cursor is at end of buffer, character movement otherwise
+_autosuggest_forward_word_or_char() {
+  if [[ -n $POSTDISPLAY && -z $RBUFFER ]]; then
+    # Suggestion exists AND cursor is at end - accept word by word
+    zle forward-word
+  else
+    # Cursor is within buffer OR no suggestion - move forward one character
+    zle forward-char
+  fi
+}
+
+# Register the custom widget
+zle -N _autosuggest_forward_word_or_char
+
+# Bind Ctrl+F to the custom widget
+bindkey '^F' _autosuggest_forward_word_or_char


### PR DESCRIPTION
## Summary

Configure zsh-autosuggestions with custom keybindings to accept suggestions with different granularities while preserving normal cursor movement behavior.

## Changes

- Create `keybindings.zsh` with custom widget configuration
- Add custom widget `_autosuggest_forward_word_or_char` for Ctrl+F that conditionally uses `forward-word` or `forward-char` based on whether a suggestion exists and cursor is at end of buffer
- Configure widget arrays to keep `forward-char` in `PARTIAL_ACCEPT_WIDGETS`
- Load keybindings before zsh-autosuggestions plugin in `.zshrc`

## Behavior

**When suggestion exists:**
- Right arrow (→): Accept character-by-character
- Ctrl+F: Accept word-by-word (only when cursor is at end)
- End/Ctrl+E: Accept entire suggestion

**When no suggestion or cursor is within buffer:**
- Right arrow (→): Move forward one character
- Ctrl+F: Move forward one character
- End/Ctrl+E: Move to end of line

## Test Plan

- [x] Right arrow accepts suggestions character-by-character
- [x] Ctrl+F accepts suggestions word-by-word when cursor is at end
- [x] Ctrl+F moves character-by-character when editing accepted text
- [x] End/Ctrl+E accepts entire suggestion
- [x] All keybindings work normally when no suggestion exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)